### PR TITLE
Update jenkins master for hamlet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,18 @@ COPY scripts/init/ /usr/share/jenkins/ref/init.groovy.d/
 RUN find /usr/share/jenkins/ref/init.groovy.d/ -type f -exec mv '{}' '{}'.override \;
 COPY scripts/casc/ /usr/share/jenkins/ref/casc_configs
 
-# Container Configuration 
+# Container Configuration
 USER root
 
-# Create extra volumes for logging and WAR cache location to allow for updates as part of master docker image 
+## Used to store properties files which are shared between agents
+ENV PROPERTIES_DIR="/var/opt/properties"
+
+RUN mkdir -p "${PROPERTIES_DIR}" && \
+    chown -R jenkins:jenkins "${PROPERTIES_DIR}"
+
+# Create extra volumes for logging and WAR cache location to allow for updates as part of master docker image
 RUN mkdir -p /var/log/jenkins && \
-    chown -R jenkins:jenkins /var/log/jenkins && \
-    mkdir -p /var/opt/codeontap/ && \
-    chown -R jenkins:jenkins /var/opt/codeontap/ 
+    chown -R jenkins:jenkins /var/log/jenkins &&
 
 # Change back to jenkins user to run jenkins
 USER jenkins
@@ -42,6 +46,7 @@ USER jenkins
 ENV AGENT_REMOTE_FS="/home/jenkins"
 ENV CASC_JENKINS_CONFIG="/usr/share/jenkins/ref/casc_configs"
 
+# Defaults for Jenkins Configuration
 ENV JENKINS_URL="http://localhost:8080"
 ENV JENKINS_ADMIN="root@local.host"
 ENV JENKINS_MASTER_EXECUTORS="0"
@@ -74,4 +79,3 @@ ENV JAVA_OPTS="-Dhudson.DNSMultiCast.disabled=true \
                 -Dhudson.slaves.NodeProvisioner.initialDelay=0 \
                 -Dhudson.slaves.NodeProvisioner.MARGIN=50 \
                 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85"
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jenkins Master for Codeontap
 
-This container provides a standard Jenkins install which we recommended for CodeOnTap ( https://codeontap.io ) deployments.
-The container also supports deployment using the CodeOnTap framework along with using this Jenkins server to deploy other products.
+This container provides a standard Jenkins install which we recommended for hamlet ( https://codeontap.io ) deployments.
+The container also supports deployment using the Hamlet along with using this Jenkins server to deploy other products.
 
 ## Environment Variables
 
@@ -16,11 +16,20 @@ The container also supports deployment using the CodeOnTap framework along with 
 ### Agent Configuration
 
 This Jenkins instance is designed to work with container based on-demand agents
+You can currently use Amazon ECS Agents via the amazon-ecs plugin
 
-- JENKINSENV_SLAVEPROVIDER
+- ECS_ARN - The ARN for the ECS cluster to run the task on
+- AGENT_JNLP_TUNNEL - An alternate hostname:port combination which can be used to provide a new network path to the JNLP endpoint
+- AGENT_JENKINS_URL - An alternate Url which can be used to provide a new network path to the JNLP endpoint
+- AGENT_REMOTE_FS - The path on the agent which will be used as the agent users home
 
-- SLAVE_<NAME>_ECSHOST
-- SLAVE_<NAME>_DEFINITION
+Multiple agent labels with their own task definitions are supported
+
+- ECS_AGENT_PREFIX - Sets the prefix used to search in environment variables for the agents
+
+Agents can then be defined using the following syntax
+
+- <ECS_AGENT_PREFIX>_<Agent_Label>_DEFINITION - ECS Task Definition Id or Arn
 
 ### Security Realm
 

--- a/scripts/init/configure-slaves-ecs.groovy
+++ b/scripts/init/configure-slaves-ecs.groovy
@@ -32,31 +32,65 @@ import java.util.logging.Logger;
 
 def env = System.getenv()
 
-Logger.global.info("[Running] Creating agent definition using provider: " + env.JENKINSENV_SLAVEPROVIDER )
+Logger.global.info("[Running] Creating agent definition for ECS Agents" )
 
-if ( env.JENKINSENV_SLAVEPROVIDER == "ecs" ) { 
+ecsAgentEnvPrefix = env.ECS_AGENT_PREFIX ?: "SLAVE"
 
-    def String defaultTaskCPU = env.SLAVE_DEFAULT_CPU ?: "128"
-    def String defaultTaskSoftMemory = env.SLAVE_DEFAULT_SOFT_MEMORY ?: "128"
-    def String defaultTaskHardMemory = env.SLAVE_DEFAULT_HARD_MEMORY ?: "0"
-
+if ( (env.findResults {  k, v -> k.startsWith(ecsAgentEnvPrefix) == true }).contains(true)  ) {
     Logger.global.info("[Running] Configuring ECS as agent provider")
-    configureCloud(defaultTaskCPU.toInteger(), defaultTaskSoftMemory.toInteger(), defaultTaskHardMemory.toInteger())
+
+    try {
+        // Environment Variable based tasks using existing defintions
+        def ecsTemplates = getEnvTaskTemplates(ecsAgentEnvPrefix)
+
+        Logger.global.info( "Found ${ecsTemplates.size()} Task Definitions" )
+        String envClusterArn = env.ECS_ARN
+        String clusterArn = queryJenkinsClusterArn(region, envClusterArn)
+
+        String jnlpTunnel = env.AGENT_JNLP_TUNNEL ?: null
+        String jenkinsInternalUrl = env.AGENT_JENKINS_URL ?: null
+
+        Logger.global.info("Creating ECS cloud for $clusterArn")
+        def ecsCloud = new ECSCloud(
+                name = "jenkins_cluster",
+                credentialsId=null,
+                cluster = clusterArn
+        )
+
+        ecsCloud.setRegionName(getRegion())
+
+        ecsCloud.setSlaveTimeoutInSeconds(300)
+
+        if ( ecsTemplates ) {
+            ecsCloud.setTemplates(ecsTemplates)
+        }
+
+        if ( jenkinsInternalUrl ) {
+            ecsCloud.setJenkinsUrl(jenkinsInternalUrl)
+        }
+
+        if (jnlpTunnel) {
+            ecsCloud.setTunnel(jnlpTunnel)
+        }
+
+        Jenkins.instance.clouds.clear()
+        Jenkins.instance.clouds.add(ecsCloud)
+
+    } catch (com.amazonaws.SdkClientException e) {
+        Logger.global.severe({ e.message })
+        Logger.global.severe("ERROR: Could not create ECS config, are you running this container in AWS?")
+    }
+
+
     Jenkins.instance.save()
     Logger.global.info("[Done] ECS agent provider configuraton finished ")
-
 }
 
 private String getRegion() {
-
     def env =  System.getenv()
     def region = EC2MetadataUtils.getEC2InstanceRegion() ?: env.DEFAULT_AWS_REGION
 }
 
-private String getClusterArn() {
-    def env = System.getenv()
-    return env.ECS_ARN
-}
 
 private getClientConfiguration() {
     new ClientConfiguration()
@@ -70,88 +104,23 @@ private String getJenkinsURL() {
 private String queryJenkinsClusterArn(String regionName, String clusterArn) {
 
     if ( clusterArn.startsWith("arn:") ) {
-        return clusterArn 
-    } 
-    else { 
+        return clusterArn
+    }
+    else {
         AmazonECSClient client = new AmazonECSClient(clientConfiguration)
         client.setRegion(RegionUtils.getRegion(regionName))
         return client.listClusters().getClusterArns().find { it.contains(clusterArn) }
     }
 }
 
-private void configureCloud( int defaultTaskCPU, int defaultTaskSoftMemory, int defaultTaskHardMemory ) {
-    try {
-        Logger.global.info("Building ECS Task Definition Templates")
-
-        // Explicit Task Definitions 
-        def ecsTemplates = templates = Arrays.asList(
-            //createECSTaskTemplate('codeontap-something', 'codeontap/gen3:jenkinsslave-stable', defaultTaskCPU, defaultTaskSoftMemory),
-            //createECSTaskTemplate('codeontap-latest', 'codeontap/gen3:jenkinsslave-latest', defaultTaskCPU, defaultTaskSoftMemory),
-        )
-
-        // Environment Variable based tasks using existing defintions 
-        ecsTemplates += getEnvTaskTemplates(defaultTaskCPU, defaultTaskSoftMemory, defaultTaskHardMemory )
-
-        Logger.global.info( "Found ${ecsTemplates.size()} Task Definitions" )
-        String envClusterArn = getClusterArn()
-        String clusterArn = queryJenkinsClusterArn(region, envClusterArn)
-
-        def env = System.getenv()
-        String jnlpTunnel = env.AGENT_JNLP_TUNNEL ?: null
-        String jenkinsInternalUrl = env.AGENT_JENKINS_URL ?: null
-
-        Logger.global.info("Creating ECS cloud for $clusterArn")
-        def ecsCloud = new ECSCloud(
-                name = "jenkins_cluster",
-                templates = ecsTemplates,
-                credentialsId = '',
-                cluster = clusterArn,
-                regionName = region,
-                jenkinsUrl = jenkinsInternalUrl,
-                slaveTimoutInSeconds = 300
-        )
-
-        if (jnlpTunnel) {
-            ecsCloud.setTunnel(jnlpTunnel)
-        }        
-
-        Jenkins.instance.clouds.clear()
-        Jenkins.instance.clouds.add(ecsCloud)
-    } catch (com.amazonaws.SdkClientException e) {
-        Logger.global.severe({ e.message })
-        Logger.global.severe("ERROR: Could not create ECS config, are you running this container in AWS?")
-    }
-}
-
-private ECSTaskTemplate createECSTaskTemplate(String label, String image, String launchType, int softMemory, int cpu) {
-    Logger.global.info("Creating ECS Template '$label' for image '$image' (memory: softMemory, cpu: $cpu)")
-
-    new ECSTaskTemplate(
-            templateName = label,
-            label = label,
-            image = image,
-            remoteFSRoot = "/home/jenkins",
-            //memory reserved
-            memory = 0,
-            //soft memory
-            launchType=launchType,
-            memoryReservation = softMemory,
-            cpu = cpu,
-            privileged = false,
-            containerUser = null,
-            logDriverOptions = null,
-            environments = null,
-            extraHosts = null,
-            mountPoints = null,
-            portMappings = null
-    )
-}
-
-private ArrayList<ECSTaskTemplate> getEnvTaskTemplates( int cpu, int softMemory, int hardMemory) {
+private ArrayList<ECSTaskTemplate> getEnvTaskTemplates(String ecsAgentEnvPrefix) {
 
     def env = System.getenv()
     def remoteFS = env.AGENT_REMOTE_FS ?: "/home/jenkins"
-    def templates = env.findResults {  k, v -> k.startsWith("SLAVE") == true ? [ k.split("_")[1..-1].reverse()[1..-1].reverse().join("-"), k.split("_").reverse()[0],v ] : null }
+
+    def ecsAgentPrefixLength = ecsAgentEnvPrefix.split('_').size()
+
+    def templates = env.findResults {  k, v -> k.startsWith(ecsAgentEnvPrefix) == true ? [ (k.split("_")[-2..ecsAgentPrefixLength].reverse()).join("-"), k.split("_").reverse()[0], v ] : null }
     templates = templates.groupBy( { template -> template[0] })
 
     Logger.global.info(" '$templates' ")
@@ -160,47 +129,47 @@ private ArrayList<ECSTaskTemplate> getEnvTaskTemplates( int cpu, int softMemory,
 
     for ( String key in templates.keySet() ) {
 
-        def ecsHost = ""
         def definitionName = ""
 
         properties = templates.get(key)
-        for ( property in properties ) { 
-            switch (property[1]) { 
-                case "ECSHOST":
-                    ecsHost = property[2]
-                    break
+        for ( property in properties ) {
+            switch (property[1]) {
                 case "DEFINITION":
                     definitionName = property[2]
                     break
             }
-        }        
+        }
 
         taskTemplate = new ECSTaskTemplate(
-                templateName = key.toLowerCase(),
-                label = key.toLowerCase(),
-                taskDefinitionOverride = definitionName,
-                image = "gen3",
-                launchType = "EC2",
-                remoteFSRoot = remoteFS,
-                //memory reserved
-                memory = hardMemory,
-                //soft memory
-                memoryReservation = softMemory,
-                cpu = cpu,
-                subnets = null,
-                securityGroups = null,
-                assignPublicIp = false,
-                privileged = false,
-                containerUser = null,
-                logDriverOptions = null,
-                environments = null,
-                extraHosts = null,
-                mountPoints = null,
-                portMappings = null
-            )
-
+            templateName = key.toLowerCase(),
+            label = key.toLowerCase(),
+            taskDefinitionOverride = definitionName,
+            image = "jenkins/jnlp-slave",
+            repositoryCredentials = null,
+            launchType = "EC2",
+            networkMode = "default",
+            remoteFSRoot = null,
+            uniqueRemoteFSRoot = false,
+            memory = 0 ,
+            memoryReservation = 128,
+            cpu = 128,
+            subnets = null,
+            securityGroups = null,
+            assignPublicIp = false,
+            privileged = false,
+            containerUser = null,
+            logDriverOptions = null,
+            environments = null,
+            extraHosts = null,
+            mountPoints = null,
+            portMappings = null,
+            executionRole = null,
+            placementStrategies = null,
+            taskrole = null,
+            inheritFrom= null,
+            sharedMemorySize = 64
+        )
         taskTemplates.push(taskTemplate)
-            
     }
     return taskTemplates
 }

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -5,30 +5,28 @@ timestamper
 ws-cleanup
 saferestart
 mailer
-build-name-setter
+job-dsl
 
 # install User Management and Security plugins
 script-security
 credentials
 credentials-binding
 matrix-auth
-pam-auth
-github-oauth
 saml
-oic-auth
 
 # install Source Code Management plugins
 git
 
-# install Organisation and Administration plugins
+# Formatting
 antisamy-markup-formatter
-github-organization-folder
 
 # install Pipelines and Continuous Delivery plugins
 workflow-aggregator
 workflow-multibranch
 pipeline-stage-view
+github-organization-folder
 github-branch-source
+ghprb
 pipeline-utility-steps
 
 # blueocean UI
@@ -42,9 +40,7 @@ build-user-vars-plugin
 envinject
 parameterized-trigger
 generic-webhook-trigger
-
 configuration-as-code
-configuration-as-code-support
 
 # Monitoring
 metrics
@@ -52,7 +48,7 @@ metrics
 # AWS Specific plugins
 aws-java-sdk
 aws-credentials
-amazon-ecs:1.16
+amazon-ecs:1.26
 
 # testing reports
 junit


### PR DESCRIPTION
A few updates to the jenkins master image 

- Changes properties file location to a variable - allows for the change of name for `/var/opt/codeontap/` - Environment Variable: `PROPERTIES_DIR`
- Rename Slave to Agent inline with Jenkins upstream and wider community feeling 
    - Prefix is now configurable to specify the ECS agent configuration - ECS_AGENT_PREFIX sets the prefix used to find the agents 
- Only one ECS cluster is supported for the environment variable agent definitions 
- AGENT_JNLP_TUNNEL - AGENT_JENKINS_URL  - Allows for the ovveride of URL/Hostnames when the agent uses to connect back to jenkins - Can be used for network load balancer alternate endpoints or local container port endpoints 
- Bump amazon-ecs container version up 
